### PR TITLE
Add CLI timer that displays elapsed time every second

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const startTime = Date.now();
+
+const timer = setInterval(() => {
+  const elapsed = Math.floor((Date.now() - startTime) / 1000);
+  process.stdout.write(`\r経過時間: ${elapsed}秒`);
+}, 1000);
+
+process.on('SIGINT', () => {
+  clearInterval(timer);
+  console.log('\n終了しました');
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gh-observer",
+  "version": "1.0.0",
+  "description": "A CLI tool that displays elapsed time every second",
+  "main": "index.js",
+  "bin": {
+    "gh-observer": "./index.js"
+  },
+  "scripts": {
+    "test": "node index.js"
+  },
+  "keywords": ["cli", "timer"],
+  "author": "s4na",
+  "license": "ISC"
+}


### PR DESCRIPTION
## Summary
- 1秒ごとに経過時間を表示するCLIツールを実装
- `npx github:s4na/gh-observer` で実行可能
- Ctrl+Cで終了

## Test plan
- [x] `node index.js` で動作確認済み
- [x] 1秒ごとに経過時間が表示されることを確認
- [x] Ctrl+Cで正常に終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)