### PR TITLE
Add -y flag to README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 以下のコマンドで実行できます:
 
 ```bash
-npx github:s4na/gh-observer
+npx github:s4na/gh-observer -y
 ```
+
+※ `-y` フラグを付けることで、毎回の同意確認をスキップできます。
 
 実行すると、1秒ごとに経過時間が表示されます。
 


### PR DESCRIPTION
## Summary
- Update README to include `-y` flag in the npx command example
- Add explanation about the `-y` flag to skip confirmation prompts

## Changes
- Changed `npx github:s4na/gh-observer` to `npx github:s4na/gh-observer -y` in README
- Added note explaining that `-y` flag skips confirmation prompts for convenience

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm the explanation is clear for users

🤖 Generated with [Claude Code](https://claude.com/claude-code)