### PR TITLE
Add config file support at ~/.config/s4na-gh-observer.yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,54 @@
 #!/usr/bin/env node
 
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const os = require('os');
+
+const CONFIG_DIR = path.join(os.homedir(), '.config');
+const CONFIG_FILE = path.join(CONFIG_DIR, 's4na-gh-observer.yaml');
+
+const ensureConfigFile = () => {
+  try {
+    if (!fs.existsSync(CONFIG_DIR)) {
+      fs.mkdirSync(CONFIG_DIR, { recursive: true });
+      console.log(`Created config directory: ${CONFIG_DIR}`);
+    }
+
+    if (!fs.existsSync(CONFIG_FILE)) {
+      const defaultConfig = {
+        interval: 1000,
+        showElapsedTime: true,
+        timeFormat: '24h',
+        createdAt: new Date().toISOString()
+      };
+
+      const yamlContent = yaml.dump(defaultConfig, {
+        indent: 2,
+        lineWidth: -1
+      });
+
+      fs.writeFileSync(CONFIG_FILE, yamlContent, 'utf8');
+      console.log(`Created config file: ${CONFIG_FILE}`);
+      return defaultConfig;
+    } else {
+      const fileContent = fs.readFileSync(CONFIG_FILE, 'utf8');
+      const config = yaml.load(fileContent);
+      console.log(`Loaded config from: ${CONFIG_FILE}`);
+      return config;
+    }
+  } catch (error) {
+    console.error(`Error handling config file: ${error.message}`);
+    return {
+      interval: 1000,
+      showElapsedTime: true,
+      timeFormat: '24h'
+    };
+  }
+};
+
+const config = ensureConfigFile();
+
 const startTime = Date.now();
 
 const formatTime = (date) => {
@@ -13,7 +62,7 @@ const timer = setInterval(() => {
   const now = new Date();
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
   console.log(`${formatTime(now)} 経過時間: ${elapsed}秒`);
-}, 1000);
+}, config.interval || 1000);
 
 process.on('SIGINT', () => {
   clearInterval(timer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "gh-observer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gh-observer",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "js-yaml": "^4.1.1"
+      },
+      "bin": {
+        "gh-observer": "index.js"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
   "scripts": {
     "test": "node index.js"
   },
-  "keywords": ["cli", "timer"],
+  "keywords": [
+    "cli",
+    "timer"
+  ],
   "author": "s4na",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "js-yaml": "^4.1.1"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds automatic config file creation and loading at `~/.config/s4na-gh-observer.yaml`
- Config file is created with default settings on first run
- Subsequent runs load existing config
- Includes settings for `interval`, `timeFormat`, `showElapsedTime`, and `createdAt`

## Implementation Details
- Uses `js-yaml` for YAML parsing and serialization
- Creates `~/.config` directory if it doesn't exist
- Gracefully handles errors with fallback to default config
- Config is applied to the timer interval

## Testing
Tested locally:
- ✅ Config file is created on first run at `~/.config/s4na-gh-observer.yaml`
- ✅ Config file is loaded on subsequent runs
- ✅ Timer respects interval setting from config

## Potential Considerations (for review)
While YAML format works well for this use case, here are some points to consider:

1. **YAML vs JSON**: YAML is human-readable and allows comments, but adds a dependency. If simplicity is preferred, JSON would work without external dependencies.

2. **Config location**: Using `~/.config/` follows XDG Base Directory specification, which is standard on Linux/macOS. This should work well for most users.

3. **Windows compatibility**: On Windows, `~/.config/` will resolve to the user's home directory, which is acceptable but not the typical Windows convention (`%APPDATA%`). If Windows support is important, consider using a cross-platform config path resolver.

4. **Config validation**: Currently, the code doesn't validate config values. Malformed values could cause unexpected behavior. Consider adding validation in future iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
