### PR TITLE
Fix npx command syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 以下のコマンドで実行できます:
 
 ```bash
-npx github:s4na/gh-observer -y
+npx -y github:s4na/gh-observer
 ```
 
-※ `-y` フラグを付けることで、毎回の同意確認をスキップできます。
+※ `-y` フラグを付けることで、パッケージインストールの同意確認をスキップできます。
 
 実行すると、1秒ごとに経過時間が表示されます。
 
@@ -32,8 +32,8 @@ node index.js
 ```
 
 ## TODO
-- [ ] npx github:s4na/gh-observer -y　って入力したら、web uiが表示されてそこでrepoを選択 & 追加できるようにする
-- [ ] 設定ファイルは永続的に残る。 ~/config/ あたりにでも置いておく
-- [ ] npx github:s4na/gh-observer -y って実行したら、 gh issue を監視して、新しい issue ができたら log に表示できるようにする
+- [ ] npx -y github:s4na/gh-observer　って入力したら、web uiが表示されてそこでrepoを選択 & 追加できるようにする
+- [x] 設定ファイルは永続的に残る。 ~/.config/ に置く
+- [ ] npx -y github:s4na/gh-observer って実行したら、 gh issue を監視して、新しい issue ができたら log に表示できるようにする
 - [ ] 新規prについて /review で自動でレビューした上で、レビュー結果をprコメントとして投稿するようにする
 - [ ] 新規issueについて、pr作成までできるようにする


### PR DESCRIPTION
## Summary
Fix the npx command syntax in README to correctly skip the installation prompt.

## Changes
- Changed `npx github:s4na/gh-observer -y` to `npx -y github:s4na/gh-observer`
- Updated the explanation to clarify that `-y` skips the package installation prompt
- Marked the config file TODO as completed

## Reason
The `-y` flag is an `npx` flag that must come before the package name, not after. When placed after the package name, users are still prompted with "Ok to proceed? (y)" during installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
