### PR TITLE
ログフォーマットを統一

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,25 @@ const os = require('os');
 const CONFIG_DIR = path.join(os.homedir(), '.config');
 const CONFIG_FILE = path.join(CONFIG_DIR, 's4na-gh-observer.yaml');
 
+// ログフォーマット関数: ログレベル、日時、内容を整形して出力
+const formatTime = (date) => {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+};
+
+const log = (level, message) => {
+  const now = new Date();
+  const timestamp = formatTime(now);
+  console.log(`${level} ${timestamp} ${message}`);
+};
+
 const ensureConfigFile = () => {
   try {
     if (!fs.existsSync(CONFIG_DIR)) {
       fs.mkdirSync(CONFIG_DIR, { recursive: true });
-      console.log(`Created config directory: ${CONFIG_DIR}`);
+      log('INFO', `Created config directory: ${CONFIG_DIR}`);
     }
 
     if (!fs.existsSync(CONFIG_FILE)) {
@@ -29,16 +43,16 @@ const ensureConfigFile = () => {
       });
 
       fs.writeFileSync(CONFIG_FILE, yamlContent, 'utf8');
-      console.log(`Created config file: ${CONFIG_FILE}`);
+      log('INFO', `Created config file: ${CONFIG_FILE}`);
       return defaultConfig;
     } else {
       const fileContent = fs.readFileSync(CONFIG_FILE, 'utf8');
       const config = yaml.load(fileContent);
-      console.log(`Loaded config from: ${CONFIG_FILE}`);
+      log('INFO', `Loaded config from: ${CONFIG_FILE}`);
       return config;
     }
   } catch (error) {
-    console.error(`Error handling config file: ${error.message}`);
+    log('ERROR', `Error handling config file: ${error.message}`);
     return {
       interval: 1000,
       showElapsedTime: true,
@@ -51,21 +65,13 @@ const config = ensureConfigFile();
 
 const startTime = Date.now();
 
-const formatTime = (date) => {
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
-  return `${hours}:${minutes}:${seconds}`;
-};
-
 const timer = setInterval(() => {
-  const now = new Date();
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
-  console.log(`${formatTime(now)} 経過時間: ${elapsed}秒`);
+  log('INFO', `経過時間: ${elapsed}秒`);
 }, config.interval || 1000);
 
 process.on('SIGINT', () => {
   clearInterval(timer);
-  console.log('\n終了しました');
+  log('INFO', '\n終了しました');
   process.exit(0);
 });


### PR DESCRIPTION
## 概要
- `log(level, message)`関数を実装し、ログ出力を統一
- 出力フォーマット: `ログレベル HH:MM:SS 内容`
- すべてのconsole.log/console.errorをlog関数に置き換え

## 変更内容
- ログフォーマット関数`log(level, message)`を追加
- `formatTime()`関数でタイムスタンプを生成（HH:MM:SS形式）
- ログレベル（INFO/ERROR）を明示的に指定
- 既存のすべてのログ出力を新しい関数に移行

## テスト計画
- [ ] プログラムを実行してログフォーマットが正しく表示されることを確認
- [ ] 設定ファイル作成時のログが正しく出力されることを確認
- [ ] エラー時のログが正しく出力されることを確認
- [ ] Ctrl+Cで終了時のログが正しく出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)