### PR TITLE
Webサーバー起動とブラウザ自動起動機能を追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const os = require('os');
+const http = require('http');
+const { exec } = require('child_process');
 
 const CONFIG_DIR = path.join(os.homedir(), '.config');
 const CONFIG_FILE = path.join(CONFIG_DIR, 's4na-gh-observer.yaml');
@@ -65,6 +67,129 @@ const config = ensureConfigFile();
 
 const startTime = Date.now();
 
+// ブラウザを開く関数
+const openBrowser = (url) => {
+  const platform = process.platform;
+  let command;
+
+  if (platform === 'darwin') {
+    command = `open ${url}`;
+  } else if (platform === 'win32') {
+    command = `start ${url}`;
+  } else {
+    command = `xdg-open ${url}`;
+  }
+
+  exec(command, (error) => {
+    if (error) {
+      log('ERROR', `ブラウザを開けませんでした: ${error.message}`);
+    }
+  });
+};
+
+// HTMLコンテンツを生成する関数
+const generateHTML = (elapsed) => {
+  return `
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GitHub Observer</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+    .container {
+      background: white;
+      padding: 3rem;
+      border-radius: 20px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      text-align: center;
+      min-width: 400px;
+    }
+    h1 {
+      color: #333;
+      margin-bottom: 2rem;
+      font-size: 2.5rem;
+    }
+    .elapsed-time {
+      font-size: 4rem;
+      font-weight: bold;
+      color: #667eea;
+      margin: 2rem 0;
+      font-variant-numeric: tabular-nums;
+    }
+    .label {
+      color: #666;
+      font-size: 1.2rem;
+      margin-bottom: 1rem;
+    }
+    .info {
+      margin-top: 2rem;
+      padding: 1rem;
+      background: #f5f5f5;
+      border-radius: 10px;
+      font-size: 0.9rem;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>📊 GitHub Observer</h1>
+    <div class="label">経過時間</div>
+    <div class="elapsed-time" id="elapsed">${elapsed}秒</div>
+    <div class="info">
+      このページは自動的に更新されます<br>
+      停止するには、ターミナルで Ctrl+C を押してください
+    </div>
+  </div>
+  <script>
+    // 1秒ごとにページを更新
+    setInterval(() => {
+      fetch('/api/elapsed')
+        .then(res => res.json())
+        .then(data => {
+          document.getElementById('elapsed').textContent = data.elapsed + '秒';
+        })
+        .catch(err => console.error('更新エラー:', err));
+    }, 1000);
+  </script>
+</body>
+</html>
+  `;
+};
+
+// HTTPサーバーを作成
+const PORT = 3000;
+const server = http.createServer((req, res) => {
+  const elapsed = Math.floor((Date.now() - startTime) / 1000);
+
+  if (req.url === '/api/elapsed') {
+    // API エンドポイント: 経過時間をJSON形式で返す
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ elapsed }));
+  } else {
+    // メインページ: HTMLを返す
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(generateHTML(elapsed));
+  }
+});
+
+server.listen(PORT, () => {
+  log('INFO', `Webサーバーを起動しました: http://localhost:${PORT}`);
+  // サーバー起動後にブラウザを開く
+  openBrowser(`http://localhost:${PORT}`);
+});
+
+// ターミナルにも経過時間を表示し続ける
 const timer = setInterval(() => {
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
   log('INFO', `経過時間: ${elapsed}秒`);
@@ -72,6 +197,8 @@ const timer = setInterval(() => {
 
 process.on('SIGINT', () => {
   clearInterval(timer);
-  log('INFO', '\n終了しました');
-  process.exit(0);
+  server.close(() => {
+    log('INFO', '\nサーバーを停止しました');
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
## 概要
- HTTPサーバー(ポート3000)を起動し、経過時間を表示するWebページを提供する機能を追加
- サーバー起動時に自動的にブラウザでWebページを開く機能を実装
- リアルタイムで経過時間を更新するAPIを実装

## 主な変更内容
- `http`モジュールを使用したWebサーバーの実装
- クロスプラットフォーム対応(macOS/Windows/Linux)のブラウザ自動起動処理
- `/api/elapsed`エンドポイントでJSON形式の経過時間データを提供
- モダンなUIデザインのHTMLページを実装(レスポンシブ対応)
- JavaScriptによるリアルタイム自動更新機能
- 既存のターミナル表示機能は維持
- Ctrl+Cでサーバーを正常に停止する処理を実装

## テストプラン
- [ ] `npx -y github:s4na/gh-observer@feature/open-web-server`を実行
- [ ] 自動的にブラウザが開き、Webページが表示されることを確認
- [ ] 経過時間が1秒ごとに更新されることを確認
- [ ] ターミナルにも経過時間のログが表示されることを確認
- [ ] Ctrl+Cで正常に終了することを確認
- [ ] macOS、Windows、Linuxでそれぞれ動作することを確認(可能であれば)

🤖 Generated with [Claude Code](https://claude.com/claude-code)