### PR TITLE
GitHub ActionsのNode.jsバージョンをv24に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 24.x]
 
     steps:
     - name: Checkout code
@@ -31,7 +31,7 @@ jobs:
       run: npm test
 
     - name: Upload coverage reports
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '24.x'
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false


### PR DESCRIPTION
## 概要
GitHub ActionsのテストワークフローでNode.js v24（最新のLTS）を使用するように更新しました。

## 主な変更内容

### Node.jsバージョンの更新
- **変更前**: Node.js 18.x と 20.x
- **変更後**: Node.js 20.x と 24.x

### 具体的な変更
1. テストマトリクスのバージョンを更新
   - `node-version: [18.x, 20.x]` → `node-version: [20.x, 24.x]`

2. カバレッジアップロード条件を更新
   - `if: matrix.node-version == '20.x'` → `if: matrix.node-version == '24.x'`

## 変更理由

### Node.js v24がLTSに
- Node.js v24が最新のLTS（Long Term Support）バージョンとなったため、これに対応します
- より新しい機能とセキュリティアップデートを活用できます

### 互換性の確保
- v20とv24の両方でテストすることで、幅広いNode.jsバージョンでの互換性を保証します
- v18のサポートを終了し、より現代的なNode.jsバージョンに焦点を当てます

## 影響範囲

### CI/CD
- GitHub Actionsでのテスト実行環境が更新されます
- テストは引き続き2つのバージョンで実行されます

### ユーザーへの影響
- エンドユーザーには影響ありません
- ローカル開発でもNode.js v20以上の使用を推奨します

## テストプラン
- [ ] GitHub ActionsでNode.js 20.xでのテストが成功することを確認
- [ ] GitHub ActionsでNode.js 24.xでのテストが成功することを確認
- [ ] カバレッジレポートが24.xで正しくアップロードされることを確認

## 参考
- Node.js v24はLTSとして長期サポートされます
- セキュリティアップデートと新機能を継続的に受け取れます

🤖 Generated with [Claude Code](https://claude.com/claude-code)