### PR TITLE
Node.js v24.x のみに対応

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main, feature/* ]
+    branches: [ main, feature/*, refactor/* ]
   pull_request:
     branches: [ main ]
 
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 24.x]
+        node-version: [24.x]
 
     steps:
     - name: Checkout code
@@ -31,7 +31,6 @@ jobs:
       run: npm test
 
     - name: Upload coverage reports
-      if: matrix.node-version == '24.x'
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "s4na",
   "license": "ISC",
   "engines": {
-    "node": ">=20.0.0"
+    "node": "24.x"
   },
   "dependencies": {
     "js-yaml": "^4.1.1"


### PR DESCRIPTION
## Summary
GitHub Actions で Node.js v24.x のみをテスト対象に指定し、package.json でも v24.x のみをサポート対象に限定しました。

## 変更内容

### GitHub Actions (test.yml)
```yaml
# Before
strategy:
  matrix:
    node-version: [20.x, 24.x]

# After  
strategy:
  matrix:
    node-version: [24.x]
```

追加変更:
- push トリガーに `refactor/*` ブランチを追加（TDDリファクタリング対応）
- codecov アップロード条件を削除（常に実行）

### package.json
```json
// Before
"engines": {
  "node": ">=20.0.0"
}

// After
"engines": {
  "node": "24.x"
}
```

## 利点
- Node.js v24 の最新機能をフルに活用可能
- テスト・ビルド時間の短縮
- サポート対象の明確化
- 依存関係の複雑性を削減

## CI/CD 確認事項
- [x] ローカルで全テスト PASS (62テスト)
- [x] npm test でカバレッジ 65.38% を確認
- [ ] GHA での実行確認（このPRで自動実行）

## テスト結果
```
Test Suites: 7 passed, 7 total
Tests:       62 passed, 62 total
Coverage:    65.38% statements
Time:        0.405s
```

## Breaking Changes
- **重要**: Node.js v20 を使用している環境では実行不可
- Node.js v24 へのアップグレードが必須

🤖 Generated with [Claude Code](https://claude.com/claude-code)