### PR TITLE
経過時間のログ出力を削除

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -85,12 +85,6 @@ async function startServer(config, startTime) {
       openBrowser(`http://localhost:${PORT}`);
     });
 
-    // ターミナルにも経過時間を表示し続ける
-    const timer = setInterval(() => {
-      const elapsed = Math.floor((Date.now() - startTime) / 1000);
-      log('INFO', `経過時間: ${elapsed}秒`);
-    }, config.interval || 1000);
-
     // Issue監視タイマー（1分に1回、設定されたリポジトリをチェック）
     const issueMonitorInterval = 60000; // 1分
     const issueTimer = setInterval(async () => {
@@ -112,7 +106,6 @@ async function startServer(config, startTime) {
       isShuttingDown = true;
 
       log('INFO', '\n停止処理を開始しています...');
-      clearInterval(timer);
       clearInterval(issueTimer);
 
       server.close(() => {


### PR DESCRIPTION
## 概要
ターミナルに1秒ごとに表示されていた経過時間のログ出力を削除しました。

## 変更内容
- サーバーのタイマーループ（1秒ごとのログ出力）を削除
- Issue監視タイマーは引き続き実行
- シャットダウン時の clearInterval(timer) を削除

## 補足
WebUI上での経過時間表示（`/api/elapsed`）は引き続き利用可能です。

## テスト
- ✅ 全テストスイート合格：84 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)