### PR TITLE
デバッグモードを追加：ghコマンドの実行をログ出力

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,18 @@
 
 const { ensureConfigFile } = require('./src/config');
 const { startServer } = require('./src/server');
+const { log } = require('./src/logger');
+
+// コマンドライン引数を解析
+const args = process.argv.slice(2);
+const isDebugMode = args.includes('-d') || args.includes('--debug');
+
+// グローバルデバッグモードフラグを設定
+global.debugMode = isDebugMode;
+
+if (isDebugMode) {
+  log('INFO', '🐛 デバッグモードを有効化しました。ghコマンドの実行が記録されます。');
+}
 
 // アプリケーションのメインロジック
 async function main() {

--- a/src/issue-monitor.js
+++ b/src/issue-monitor.js
@@ -35,9 +35,11 @@ async function fetchIssues(repo) {
   }
 
   try {
-    const { stdout } = await execAsync(
-      `gh issue list --repo ${repo} --json number,title,state,createdAt,updatedAt,author --limit 100`
-    );
+    const cmd = `gh issue list --repo ${repo} --json number,title,state,createdAt,updatedAt,author --limit 100`;
+    if (global.debugMode) {
+      log('DEBUG', `📋 実行: ${cmd}`);
+    }
+    const { stdout } = await execAsync(cmd);
     return JSON.parse(stdout);
   } catch (err) {
     log('WARN', `Issue取得失敗 (${repo}): ${err.message}`);
@@ -59,9 +61,11 @@ async function fetchIssueComments(repo, issueNumber) {
   }
 
   try {
-    const { stdout } = await execAsync(
-      `gh issue view ${issueNumber} --repo ${repo} --json comments`
-    );
+    const cmd = `gh issue view ${issueNumber} --repo ${repo} --json comments`;
+    if (global.debugMode) {
+      log('DEBUG', `📋 実行: ${cmd}`);
+    }
+    const { stdout } = await execAsync(cmd);
     const result = JSON.parse(stdout);
     return result.comments || [];
   } catch (err) {

--- a/src/repository.js
+++ b/src/repository.js
@@ -18,7 +18,11 @@ async function fetchRepositories() {
     // 自分のリポジトリを取得
     let userRepos = [];
     try {
-      const { stdout: userReposOutput } = await execAsync('gh repo list --json name,url,description,owner --limit 100');
+      const cmd = 'gh repo list --json name,url,description,owner --limit 100';
+      if (global.debugMode) {
+        log('DEBUG', `📋 実行: ${cmd}`);
+      }
+      const { stdout: userReposOutput } = await execAsync(cmd);
       userRepos = JSON.parse(userReposOutput);
     } catch (err) {
       log('WARN', `個人リポジトリの取得に失敗: ${err.message}`);
@@ -27,7 +31,11 @@ async function fetchRepositories() {
     // 所属している組織を取得
     let orgs = [];
     try {
-      const { stdout: orgsOutput } = await execAsync('gh api user/orgs --jq ".[].login"');
+      const cmd = 'gh api user/orgs --jq ".[].login"';
+      if (global.debugMode) {
+        log('DEBUG', `📋 実行: ${cmd}`);
+      }
+      const { stdout: orgsOutput } = await execAsync(cmd);
       orgs = orgsOutput.trim().split('\n').filter(org => org);
     } catch (err) {
       log('WARN', `組織一覧の取得に失敗: ${err.message}`);
@@ -37,7 +45,11 @@ async function fetchRepositories() {
     const orgRepos = [];
     for (const org of orgs) {
       try {
-        const { stdout: orgReposOutput } = await execAsync(`gh repo list ${org} --json name,url,description,owner --limit 100`);
+        const cmd = `gh repo list ${org} --json name,url,description,owner --limit 100`;
+        if (global.debugMode) {
+          log('DEBUG', `📋 実行: ${cmd}`);
+        }
+        const { stdout: orgReposOutput } = await execAsync(cmd);
         const repos = JSON.parse(orgReposOutput);
         orgRepos.push({
           org,


### PR DESCRIPTION
## 概要
`-d` または `--debug` オプションを指定して起動すると、
実行されるすべての gh コマンドをデバッグログとして表示します。

## 使用方法

### デバッグモード有効で起動
```bash
npx -y github:s4na/gh-observer --debug
# または
npx -y github:s4na/gh-observer -d
```

### 出力例
```
INFO 🐛 デバッグモードを有効化しました。ghコマンドの実行が記録されます。
DEBUG 📋 実行: gh repo list --json name,url,description,owner --limit 100
DEBUG 📋 実行: gh api user/orgs --jq ".[].login"
DEBUG 📋 実行: gh issue list --repo owner/repo --json number,title,state,createdAt,updatedAt,author --limit 100
```

## 変更内容

### 1. index.js でコマンドライン引数を解析
- `-d` または `--debug` オプションを検出
- `global.debugMode` フラグを設定
- デバッグモード有効化時にログを出力

### 2. repository.js にデバッグログを追加
実行されるコマンド：
- `gh repo list` - 個人リポジトリ取得
- `gh api user/orgs` - 所属組織一覧取得
- `gh repo list {org}` - 組織のリポジトリ取得

### 3. issue-monitor.js にデバッグログを追加
実行されるコマンド：
- `gh issue list` - Issue一覧取得
- `gh issue view` - Issue詳細情報取得

## メリット
- gh コマンド実行の透視性向上
- トラブルシューティングが容易
- API呼び出しの監査ログ
- パフォーマンス分析に有用

## テスト
- ✅ 全89テスト合格
- ✅ デバッグモードのオプション処理が正常に動作することを確認

## 今後の拡張
- タイムスタンプ付きのデバッグログ
- コマンド実行時間の測定
- ファイルへのログ出力オプション

🤖 Generated with [Claude Code](https://claude.com/claude-code)